### PR TITLE
Fix for multiple headers bug

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -152,8 +152,8 @@ namespace ModernHttpClient
 
             var respHeaders = resp.Headers();
             foreach (var k in respHeaders.Names()) {
-                ret.Headers.TryAddWithoutValidation(k, respHeaders.Get(k));
-                ret.Content.Headers.TryAddWithoutValidation(k, respHeaders.Get(k));
+                ret.Headers.TryAddWithoutValidation(k, respHeaders.Values(k));
+                ret.Content.Headers.TryAddWithoutValidation(k, respHeaders.Values(k));
             }
 
             return ret;


### PR DESCRIPTION
This fixes a bug where multiple headers from an HTTP request with the same name (ie Set-Cookie) only return the first value instead of an array of all values. You need to use OkHttp's Values method which returns all values instead of Get which only returns the first one.